### PR TITLE
Fix keepalive log

### DIFF
--- a/roborock/api.py
+++ b/roborock/api.py
@@ -85,7 +85,7 @@ class RoborockClient(ABC):
 
     async def validate_connection(self) -> None:
         if not self.should_keepalive():
-            self._logger.info("Resetting Roborock connection due to kepalive timeout")
+            self._logger.info("Resetting Roborock connection due to keepalive timeout")
             await self.async_disconnect()
         await self.async_connect()
 


### PR DESCRIPTION
## Summary
- fix a typo in keepalive timeout log message

## Testing
- `pre-commit run --files roborock/api.py`
- `pytest -q`
