### PR TITLE
Fix typos in MQTT session log messages

### DIFF
--- a/roborock/mqtt/roborock_session.py
+++ b/roborock/mqtt/roborock_session.py
@@ -118,7 +118,7 @@ class RoborockMqttSession(MqttSession):
                 if start_future:
                     _LOGGER.debug("MQTT loop was cancelled")
                     start_future.set_exception(err)
-                _LOGGER.debug("MQTT loop was cancelled whiel starting")
+                _LOGGER.debug("MQTT loop was cancelled while starting")
                 return
             # Catch exceptions to avoid crashing the loop
             # and to allow the loop to retry.
@@ -160,7 +160,7 @@ class RoborockMqttSession(MqttSession):
                 async with self._client_lock:
                     self._client = client
                     for topic in self._listeners:
-                        _LOGGER.debug("Re-establising subscription to topic %s", topic)
+                        _LOGGER.debug("Re-establishing subscription to topic %s", topic)
                         # TODO: If this fails it will break the whole connection. Make
                         # this retry again in the background with backoff.
                         await client.subscribe(topic)


### PR DESCRIPTION
## Summary
- fix typo in cancellation log entry
- fix typo in subscription log entry

## Testing
- `pytest -q` *(fails: tests/test_api.py::test_disconnect_already_disconnected - AttributeErr..., tests/mqtt/test_roborock_session.py::test_session - Failed: Timeout (>20.0s))*
